### PR TITLE
Change MIME type to application/octet-stream

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 					Objects: <span id="total">0</span> &nbsp;/&nbsp; After Merge: <span id="mergetotal">0</span>
 				</div>
 				<div id="help">
-					Drop file into your Templates folder (not directly in the editor).
+					Drop file into your Data/Templates folder (not directly in the editor).
 				</div>
 			</div>
 		</div>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -978,7 +978,7 @@ class Pixel_Art_To_Template {
 	}
 
 	static save(f, d, objs){
-		let blob = new Blob([d], {type: "text/plain"});
+		let blob = new Blob([d], {type: "application/octet-stream"});
 		let elem = window.document.createElement("a");
 		
 		elem.href = window.URL.createObjectURL(blob);


### PR DESCRIPTION
Some browsers (like Firefox) will automatically save a file as a ,txt if the file that will be saved if it is MIME type text/plain. Others might open it in a new tab. Changing to application/octet-stream will instead make most browsers save it as a .pbt file.
I also clarified that the file should be in Data/Templates.
It can be tested [here](https://macaylamarvelous81.github.io/Core-Image-To-Template/index.html) and I recommend testing in the Firefox browser.
By the way, thanks for this awesome tool!